### PR TITLE
increased update rate for the joint state publisher

### DIFF
--- a/launch/display_simulated_robot.launch
+++ b/launch/display_simulated_robot.launch
@@ -17,7 +17,9 @@
   </include>
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <param name="rate" value="50"/>
+  </node>
 
   <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(find robotont_nuc_description)/config/robotont_realsense.rviz -f $(arg rviz_fixed_frame)"/>
 </launch>


### PR DESCRIPTION
The default update rate for the joint state publisher is 10 Hz, which in racing mode causes Robotont's dynamic joints (the wheels) to fall behind the other parts of the robot body.
Matching the update rate of the joint state publisher with the robot state publisher's update rate (50 Hz) will improve visualization significantly.
10 Hz:
![image](https://github.com/robotont/robotont_nuc_description/assets/474082/3ccf65f2-38c7-464c-a632-dfd6994b0734)
50 Hz:
![image](https://github.com/robotont/robotont_nuc_description/assets/474082/7529ba1a-2c1e-4cdb-a8af-c58aba22bd41) 